### PR TITLE
Implement idea compact-exporting

### DIFF
--- a/examples/snippets.kju
+++ b/examples/snippets.kju
@@ -169,3 +169,4 @@ fizz_buzz (N) =
 
 f()= string:sub_string(OptStr, P, P + 2) >= "3.4"
 
+export start/1,2 end

--- a/grammar/Kju.g4
+++ b/grammar/Kju.g4
@@ -67,7 +67,7 @@ String : '"' ( '\\' (~'\\'|'\\') | ~[\\""] )* '"' ;
 
 export : 'export' fa* 'end' ;
 
-fa : atom '/' integer ;
+fa : atom '/' integer (',' integer)* ;
 
 /// def
 


### PR DESCRIPTION
Idea: `export start/1,2 end`, since `start/1,2` is common notation in the literature

``` haskell
export
    start/1,2
end
```
