### PR TITLE
Use `&&` and `||` for logic, synonyms for `andalso` and `orelse`

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Maybe Kim Jong-Un in that it is a merciless tool.
     * Implement EEP19 by transforming to long-arity recursive fun.
     * Provide a word to common spec `ok | {error, err_type()}` like `?oe(err_type())`. (Just an included macro?)
     + `<:` as the maps generator
-    * Use `&&` and `||` for logic. Replace `andalso` and `orelse`
+    + Use `&&` and `||` for logic. Replace `andalso` and `orelse`
     * Automatically-defined maps/records (inlined) getters (… not really Erlangish!)
     * `-spec` type-variables defaults to `‹term›`, ‘to mimic Haskell's type parameters’
     + Given `auto-spec-guards addition`, `--f-ascetic-guard-additions`. Don't add guards where Dialyzer says they are not needed.

--- a/examples/snippets.kju
+++ b/examples/snippets.kju
@@ -172,3 +172,6 @@ fizz_buzz (N) =
 f()= string:sub_string(OptStr, P, P + 2) >= "3.4"
 
 export start/1,2 end
+
+verify_int (Int, Max) =
+    false || verify_strict_int(Int) && verify_strict_int(Max) && Int =< Max

--- a/grammar/Kju.g4
+++ b/grammar/Kju.g4
@@ -13,6 +13,9 @@ WS : [ \t\r\n]+ -> channel(HIDDEN) ;
 
 /// Ops | Also some tokens b/c ANTLR4 bugs and concatenates lexems.
 
+orelse : '||' | 'orelse' ;  // || && will are to replace their synonyms
+andalso : '&&' | 'andalso' ;
+
 compOp : '<' | '=<' | '==' | '>=' | '>' | '/=' | '=/=' | '=:=' ;
 
 listOp : '++' | '--' ;
@@ -24,7 +27,7 @@ mulOp : '*' | '/' | 'div' | 'rem' | 'and' | 'band' ;
 
 prefixOp : '+' | '-' | 'not' | 'bnot' ;
 
-when : 'when' | '|' ;
+when : 'when' | '|' ;  // | is just to test support. Will not be part of language.
 
 etc : '...' ;//| '…' ;
 
@@ -123,32 +126,32 @@ tyFun : '(' (etc | tyMaxs)? ')' lra tyMax ;
 
 /// expr | seqExprs | exprA
 
-expr    : (expr125|lastOnly)              '='       (expr   |lastOnly|functionCall)
+expr    : (expr125|lastOnly)              '='     (expr   |lastOnly|functionCall)
         |  expr125 ;
 
-expr125 : (expr150|lastOnly|functionCall) '!'       (expr125|lastOnly|functionCall)
+expr125 : (expr150|lastOnly|functionCall) '!'     (expr125|lastOnly|functionCall)
         |  expr150 ;
 
-expr150 : (expr160|lastOnly|functionCall) 'orelse'  (expr150|lastOnly|functionCall)
+expr150 : (expr160|lastOnly|functionCall) orelse  (expr150|lastOnly|functionCall)
         |  expr160 ;
 
-expr160 : (expr200|lastOnly|functionCall) 'andalso' (expr160|lastOnly|functionCall)
+expr160 : (expr200|lastOnly|functionCall) andalso (expr160|lastOnly|functionCall)
         |  expr200 ;
 
-expr200 : (expr300|lastOnly|functionCall) compOp    (expr200|lastOnly|functionCall)
+expr200 : (expr300|lastOnly|functionCall) compOp  (expr200|lastOnly|functionCall)
         |  expr300 ;
 
-expr300 : (expr400|lastOnly|functionCall) listOp    (expr300|lastOnly|functionCall)
+expr300 : (expr400|lastOnly|functionCall) listOp  (expr300|lastOnly|functionCall)
         |  expr400 ;
 
-expr400 : (expr500|lastOnly|functionCall) addOp     (expr400|lastOnly|functionCall)
+expr400 : (expr500|lastOnly|functionCall) addOp   (expr400|lastOnly|functionCall)
         |  expr500 ;
 
-expr500 : (expr600|lastOnly|functionCall) mulOp     (expr500|lastOnly|functionCall)
+expr500 : (expr600|lastOnly|functionCall) mulOp   (expr500|lastOnly|functionCall)
         |  expr600 ;
 
-expr600 :                                 prefixOp  (exprMax|lastOnly|functionCall)
-        |                                            exprMax ;
+expr600 :                              prefixOp   (exprMax|lastOnly|functionCall)
+        |                                         exprMax ;
 
 exprMax : atomic
         //| recordExpr


### PR DESCRIPTION
``` haskell
verify_int (Int, Max) =
    false || verify_strict_int(Int) && verify_strict_int(Max) && Int =< Max
```

![antlr4_parse_tree](https://cloud.githubusercontent.com/assets/278727/2623583/f7664c46-bcf9-11e3-9c26-347b53365ab4.png)
